### PR TITLE
adds launch file

### DIFF
--- a/inorbit_republisher/launch/example.launch.xml
+++ b/inorbit_republisher/launch/example.launch.xml
@@ -1,0 +1,5 @@
+<launch>
+  <node name="inorbit_republisher" pkg="inorbit_republisher" exec="republisher">
+    <param name="config" value="$(dirname)/../config/example.yaml" />
+  </node>
+</launch>

--- a/inorbit_republisher/package.xml
+++ b/inorbit_republisher/package.xml
@@ -6,6 +6,7 @@
   <description>ROS2 to InOrbit topic republisher</description>
   <maintainer email="support@inorbit.ai">InOrbit</maintainer>
   <license>MIT</license>
+  <exec_depend>ros2launch</exec_depend>
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/inorbit_republisher/setup.py
+++ b/inorbit_republisher/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+import os
+from glob import glob
 
 package_name = 'inorbit_republisher'
 
@@ -10,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name), glob('launch/*'))
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
```
-rwxr-xr-x 1 docker docker 426 Aug 14 15:51 republisher
docker@foxy-435:~/dev_ws$ colcon build
Starting >>> docker_tests
Starting >>> inorbit_republisher
Finished <<< docker_tests [0.31s]                                                           
Finished <<< inorbit_republisher [0.76s]          

Summary: 2 packages finished [0.88s]
docker@foxy-435:~/dev_ws$ ros2 launch inorbit_republisher example.launch.xml
[INFO] [launch]: All log files can be found below /home/docker/.ros/log/2023-08-14-15-51-54-483332-foxy-435-1154
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [republisher-1]: process started with pid [1156]
[INFO] [republisher-1]: process has finished cleanly [pid 1156]
```