### PR TITLE
Params ported to ros2

### DIFF
--- a/inorbit_republisher/inorbit_republisher/republisher.py
+++ b/inorbit_republisher/inorbit_republisher/republisher.py
@@ -28,7 +28,7 @@
 #import json
 import rclpy
 #import genpy
-#import yaml
+import yaml
 #import rospkg
 #import os
 #from std_msgs.msg import String
@@ -54,19 +54,17 @@ as complexity increases.
 def main(args = None):
     # Start the ROS node
     rclpy.init(args=args)
-    rclpy.create_node('inorbit_republisher')
-    
-
+    node = rclpy.create_node('inorbit_republisher')
+    # Declares the "config" parameter, it contains the path of the config file
+    node.declare_parameter('config')
     # Read republisher configuration from the 'config_file' or 'config' parameter
     # TODO(adamantivm) Error handling and schema checking
-    # if rospy.has_param('~config_file'):
-    #     config_file = rospy.get_param('~config_file')
-    #     rospy.loginfo("Using config from config file: {}".format(config_file))
-    #     config_yaml = open(config_file, "r")
-    # elif rospy.has_param('~config'):
-    #     config_yaml = rospy.get_param('~config')
-    #     rospy.loginfo("Using config from parameter server")
-    # config = yaml.safe_load(config_yaml)
+    if node.has_parameter('config'):
+        config_file = node.get_parameter(
+            'config').get_parameter_value().string_value
+        node.get_logger().info("Using config from config file: {}".format(config_file))
+        config_yaml = open(config_file, "r")
+    #config = yaml.safe_load(config_yaml)
 
     # # Go through republisher configurations
     # # For each of them: create a publisher if necessary - only one per InOrbit
@@ -162,7 +160,7 @@ def main(args = None):
     #         pub.publish(String("{}={}".format(key, val)))
 
     # rospy.loginfo('Republisher started')
-    # rospy.spin()
+    rclpy.spin(node)
     # rospy.loginfo('Republisher shutting down')
 
     # # Disconnect subs and pubs

--- a/inorbit_republisher/inorbit_republisher/republisher.py
+++ b/inorbit_republisher/inorbit_republisher/republisher.py
@@ -28,7 +28,7 @@
 #import json
 import rclpy
 #import genpy
-import yaml
+#import yaml
 #import rospkg
 #import os
 #from std_msgs.msg import String


### PR DESCRIPTION
- Ported params to ROS2 way
- Added ros2 spin
- Now params are a "Path" so it doesn't make sense to have 2 params (config or config_file), now it is always a path to a file

Demo (you may notice a problem when opening the file, that's because the path is wrongly sent by the launch xml):  
  
```
docker@foxy-381:~/dev_ws$ ros2 launch  inorbit_republisher example.launch.xml
[INFO] [launch]: All log files can be found below /home/docker/.ros/log/2023-08-14-18-16-28-857683-foxy-381-2133
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [republisher-1]: process started with pid [2135]
[republisher-1] [INFO] [1692036989.155583390] [inorbit_republisher]: Using config from config file: /home/docker/dev_ws/install/inorbit_republisher/share/inorbit_republisher/../config/example.yaml
[republisher-1] Traceback (most recent call last):
[republisher-1]   File "/home/docker/dev_ws/install/inorbit_republisher/lib/inorbit_republisher/republisher", line 11, in <module>
[republisher-1]     load_entry_point('inorbit-republisher==0.2.5', 'console_scripts', 'republisher')()
[republisher-1]   File "/home/docker/dev_ws/install/inorbit_republisher/lib/python3.8/site-packages/inorbit_republisher/republisher.py", line 66, in main
[republisher-1]     config_yaml = open(config_file, "r")
[republisher-1] FileNotFoundError: [Errno 2] No such file or directory: '/home/docker/dev_ws/install/inorbit_republisher/share/inorbit_republisher/../config/example.yaml'
[ERROR] [republisher-1]: process has died [pid 2135, exit code 1, cmd '/home/docker/dev_ws/install/inorbit_republisher/lib/inorbit_republisher/republisher --ros-args -r __node:=inorbit_republisher --params-file /tmp/launch_params_wlaesn47'].
```
