### PR TITLE
Dynamic type imports and fixes launch file

### DIFF
--- a/inorbit_republisher/inorbit_republisher/republisher.py
+++ b/inorbit_republisher/inorbit_republisher/republisher.py
@@ -89,7 +89,7 @@ def main(args = None):
         # Load subscriber message type
         msg_class = get_message(repub['msg_type'])
         if msg_class is None:
-            rospy.logwarn('Failed to load msg class for {}'.format(repub['msg_type']))
+            node.get_logger().warning('Failed to load msg class for {}'.format(repub['msg_type']))
             continue
 
         # Create publisher for each new seen outgoing topic

--- a/inorbit_republisher/launch/example.launch.xml
+++ b/inorbit_republisher/launch/example.launch.xml
@@ -1,5 +1,5 @@
 <launch>
   <node name="inorbit_republisher" pkg="inorbit_republisher" exec="republisher">
-    <param name="config" value="$(dirname)/../config/example.yaml" />
+    <param name="config" value="$(dirname)/config/example.yaml" />
   </node>
 </launch>

--- a/inorbit_republisher/setup.py
+++ b/inorbit_republisher/setup.py
@@ -12,7 +12,8 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name), glob('launch/*'))
+        (os.path.join('share', package_name), glob('launch/*')),
+        (os.path.join('share', package_name, 'config'), glob('config/*'))
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
Fixes the launch file.

```
docker@foxy-435:~/dev_ws$ ros2 launch inorbit_republisher example.launch.xml 
[INFO] [launch]: All log files can be found below /home/docker/.ros/log/2023-08-14-20-16-47-479231-foxy-435-2480
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [republisher-1]: process started with pid [2482]
[republisher-1] [INFO] [1692044207.890407675] [inorbit_republisher]: Using config from config file: /home/docker/dev_ws/install/inorbit_republisher/share/inorbit_republisher/config/example.yaml
```

Also, updates the code to dynamically load message types, ported to ROS 2! Not tested outside of an unrelated test scripts.

